### PR TITLE
Support reusing pushshift_working with a new file filter

### DIFF
--- a/scripts/combine_folder_multiprocess.py
+++ b/scripts/combine_folder_multiprocess.py
@@ -489,7 +489,9 @@ if __name__ == '__main__':
 	count_intermediate_files = 0
 	# build a list of output files to combine
 	for file in sorted(input_files, key=lambda item: os.path.split(item.output_path)[1]):
-		if not file.complete:
+		if re.search(args.file_filter, os.path.basename(file.input_path)) is None:
+			log.info(f"File {file.input_path} skipped based on file_filter")
+		elif not file.complete:
 			if file.error_message is not None:
 				log.info(f"File {file.input_path} errored {file.error_message}")
 			else:


### PR DESCRIPTION
This PR enables `combine_folder_multiprocess.py` to reuse an existing `pushshift_working` folder with a different `--file_filter` value.

When a new `--file_filter` is provided, the generated output files will include only data from input files that match the filter, even if `pushshift_working` contains additional data from a previous run.

This is particularly useful for partitioning output after encountering unexpectedly large results.
